### PR TITLE
Hf operation limit

### DIFF
--- a/src/Http/Controllers/OperationController.php
+++ b/src/Http/Controllers/OperationController.php
@@ -29,7 +29,7 @@ class OperationController extends Controller
 
 	public function index(Request $request)
 	{
-		$ops = Operation::all()->take(50);
+		$ops = Operation::all()->take(-50);
 		$tags = Tag::all()->sortBy('order');
 
 		$ops_incoming = $ops->filter(function($op) {


### PR DESCRIPTION
This commit fix a design issue.

Current version is displaying the top first 50 records (based on the primary key, which mean olds records first)

This fix is taking the last 50 records instead.