### PR TITLE
Provide API endpoint for operations

### DIFF
--- a/src/CalendarServiceProvider.php
+++ b/src/CalendarServiceProvider.php
@@ -23,6 +23,7 @@ class CalendarServiceProvider extends AbstractSeatPlugin
         $this->addMigrations();
         $this->addPublications();
         $this->addObservers();
+        $this->configureApi();
 
         $this->app->booted(function () {
             $schedule = $this->app->make(Schedule::class);
@@ -82,6 +83,21 @@ class CalendarServiceProvider extends AbstractSeatPlugin
     {
         $this->commands([
             RemindOperation::class,
+        ]);
+    }
+
+    private function configureApi()
+    {
+        // ensure current annotations setting is an array of path or transform into it
+        $current_annotations = config('l5-swagger.paths.annotations');
+        if (! is_array($current_annotations))
+            $current_annotations = [$current_annotations];
+        // merge paths together and update config
+        config([
+            'l5-swagger.paths.annotations' => array_unique(array_merge($current_annotations, [
+                __DIR__ . '/Models',
+                __DIR__ . '/Http/Controllers/Api/v1',
+            ])),
         ]);
     }
 

--- a/src/Http/Controllers/Api/v1/CalendarApiController.php
+++ b/src/Http/Controllers/Api/v1/CalendarApiController.php
@@ -1,0 +1,59 @@
+<?php
+namespace Seat\Kassie\Calendar\Http\Controllers\Api\v1;
+use Seat\Api\Http\Controllers\Api\v2\ApiController;
+use Seat\Kassie\Calendar\Models\Operation;
+/**
+ * Class CalendarApiController
+ * @package Seat\Kassie\Calendar\Http\Controllers\Api\v1
+ */
+class CalendarApiController extends ApiController
+{
+    /**
+     * @SWG\Get(
+     *     path="/calendar/operations",
+     *     tags={"Calendar"},
+     *     summary="Get a list of all calendar operations",
+     *     description="Returns list of all calendar operations",
+     *     security={"ApiKeyAuth"},
+     *     @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="array",
+     *              @SWG\Items(ref="#/definitions/Operation")
+     *          ),
+     *          examples={"application/json":
+     *              {
+     *                  {"title": "MOON MINING", "start_at": null, "end_at": null, "importance": "1", "description": "20% tax to Mining Lord", "staging_sys": "Jita", "staging_sys_id": 30000000, "staging_info": null, "is_cancelled": 0, "fc": "The Mittani", "fc_character_id": 12413371, "role_name": "Members" }
+     *              }
+     *          }
+     *     ),
+     *     @SWG\Response(response=400, description="Bad request"),
+     *     @SWG\Response(response=401, description="Unauthorized"),
+     *    )
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function getAllOperations()
+    {
+        $operations = Operation::all();
+        return response()->json($operations->map(
+            function($item){
+                return [
+                    'title' => $item->title,
+                    'start_at' => $item->start_at,
+                    'end_at' => $item->end_at,
+                    'importance' => $item->importance,
+                    'integration_id' => $item->integration_id,
+                    'description' => $item->description,
+                    'description_new' => $item->description_new,
+                    'staging_sys' => $item->staging_sys,
+                    'staging_sys_id' => $item->staging_sys_id,
+                    'staging_info' => $item->staging_info,
+                    'is_cancelled' => $item ->is_cancelled,
+                    'fc' => $item->fc,
+                    'fc_character_id' => $item->fc_character_id,
+                    'role_name' => $item->role_name
+                ];
+            })
+        );
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -52,8 +52,8 @@ Route::group([
 
         Route::get('/calendar/operations', 'AjaxController@getIncoming');
 
-    })
-})
+    });
+});
 
 Route::group([
     'namespace' => 'Seat\Kassie\Calendar\Http\Controllers',

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -50,7 +50,7 @@ Route::group([
         'prefix' => 'v2'
     ], function(){
 
-        Route::get('/calendar/operations', AjaxController@getIncoming');
+        Route::get('/calendar/operations', 'AjaxController@getIncoming');
 
     })
 })

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,18 +1,6 @@
 <?php
 
 Route::group([
-    'namespace' => 'Seat\Kassie\Calendar\Http\Controllers\Api\v1',
-    'prefix' => 'api',
-    'middleware' => 'api.auth'
-], function() {
-    Route::group(['prefix' => 'v2'], function () {
-        Route::group(['prefix' => 'calendar'], function () {
-                Route::get('/operations', 'CalendarApiController@getAllOperations');
-        });
-    });
-});
-
-Route::group([
     'namespace' => 'Seat\Kassie\Calendar\Http\Controllers',
     'middleware' => ['web', 'auth'],
     'prefix' => 'character',
@@ -51,6 +39,21 @@ Route::group([
     ]);
 
 });
+
+Route::group([
+    'namespace' => 'Seat\Kassie\Calendar\Http\Controllers',
+    'middleware' => ['api.auth'],
+    'prefix' => 'api'
+], function () {
+
+    Route::group([
+        'prefix' => 'v2'
+    ], function(){
+
+        Route::get('/calendar/operations', AjaxController@getIncoming');
+
+    })
+})
 
 Route::group([
     'namespace' => 'Seat\Kassie\Calendar\Http\Controllers',

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,6 +1,18 @@
 <?php
 
 Route::group([
+    'namespace' => 'Seat\Kassie\Calendar\Http\Controllers\Api\v1',
+    'prefix' => 'api',
+    'middleware' => 'api.auth'
+], function() {
+    Route::group(['prefix' => 'v2'], function () {
+        Route::group(['prefix' => 'calendar'], function () {
+                Route::get('/operations', 'CalendarApiController@getAllOperations');
+        });
+    });
+});
+
+Route::group([
     'namespace' => 'Seat\Kassie\Calendar\Http\Controllers',
     'middleware' => ['web', 'auth'],
     'prefix' => 'character',

--- a/src/Models/Operation.php
+++ b/src/Models/Operation.php
@@ -14,7 +14,92 @@ use Seat\Web\Models\User;
 /**
  * Class Operation.
  * @package Seat\Kassie\Calendar\Models
+ *
+ * @SWG\Definition(
+ *     description="Operation model",
+ *     title="Operation model",
+ *     type="object"
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Title of the operation",
+ *     property="title",
+ * )
+ *
+ * @SWG\Property(
+ *     format="object",
+ *     description="End date details",
+ *     property="end_at",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Importance of the operation",
+ *     property="importance",
+ * )
+ *
+ * @SWG\Property(
+ *     format="int",
+ *     description="ID of the integration used",
+ *     property="integration_id",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Description of the operation",
+ *     property="description",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Description (new) of the operation",
+ *     property="description_new",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Staging system name",
+ *     property="staging_sys",
+ * )
+ *
+ * @SWG\Property(
+ *     format="int",
+ *     description="EVE ID of the staging system",
+ *     property="staging_sys_id",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Staging system info",
+ *     property="staging_info",
+ * )
+ *
+ * @SWG\Property(
+ *     format="boolean",
+ *     description="Whether or not the operation is cancelled",
+ *     property="is_cancelled",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Name of the fleet commander",
+ *     property="fc",
+ * )
+ *
+ * @SWG\Property(
+ *     format="int",
+ *     description="EVE ID of the fleet commander",
+ *     property="fc_character_id",
+ * )
+ *
+ * @SWG\Property(
+ *     format="string",
+ *     description="Name of the role the operation is mapped to",
+ *     property="role_name",
+ * )
  */
+
 class Operation extends Model
 {
     use Notifiable;


### PR DESCRIPTION
So I'm extremely rusty with PHP and have no experience with Laravel whatsoever. That said, I've written a simple endpoint for SeAT's Swagger API that exposes all operations. It's been useful for my purposes, and might be for others too.

Issues with this PR:
- Still not showing up in Swagger documentation (might need some help with this)
- 