### PR TITLE
Add new End notification

### DIFF
--- a/src/Notifications/OperationEnded.php
+++ b/src/Notifications/OperationEnded.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Seat\Kassie\Calendar\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Kassie\Calendar\Helpers\Helper;
+
+/**
+ * Class OperationEnded.
+ *
+ * @package Seat\Kassie\Calendar\Notifications
+ */
+class OperationEnded extends Notification
+{
+    use Queueable;
+
+    /**
+     * @param $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function toSlack($notifiable)
+    {
+        $attachment = Helper::BuildSlackNotificationAttachment($notifiable);
+
+        return (new SlackMessage)
+            ->success()
+            ->from('SeAT Calendar', ':calendar:')
+            ->content(trans('calendar::seat.notification_end_operation'))
+            ->attachment($attachment);
+    }
+}

--- a/src/Observers/OperationObserver.php
+++ b/src/Observers/OperationObserver.php
@@ -8,6 +8,7 @@ use Seat\Kassie\Calendar\Notifications\OperationPosted;
 use Seat\Kassie\Calendar\Notifications\OperationUpdated;
 use Seat\Kassie\Calendar\Notifications\OperationCancelled;
 use Seat\Kassie\Calendar\Notifications\OperationActivated;
+use Seat\Kassie\Calendar\Notifications\OperationEnded;
 
 /**
  * Class OperationObserver.
@@ -37,6 +38,9 @@ class OperationObserver
                     Notification::send($new_operation, new OperationCancelled());
                 else
                     Notification::send($new_operation, new OperationActivated());
+            }
+            elseif ($old_operation->end_at != $new_operation->end_at && $new_operation->is_cancelled == false) {
+                Notification::send($new_operation, new OperationEnded());
             }
             else {
                 Notification::send($new_operation, new OperationUpdated());

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -103,6 +103,7 @@ return [
     'notification_cancel_operation'   => '<!channel> :no_entry_sign: An operation has been cancelled !',
     'notification_activate_operation' => '<!channel> :white_check_mark: A cancelled operation has been reactivated !',
     'notification_ping_operation'     => '<!channel> :bell: ',
+    'notification_end_operation'      => '<!here> :no_entry_sign: This operation has ended!',
     'notification_enable'             => 'Notify to Slack',
     'integration_channel'             => 'Integration Channel',
 

--- a/src/resources/lang/zh-CN/seat.php
+++ b/src/resources/lang/zh-CN/seat.php
@@ -102,6 +102,7 @@ return [
     'notification_edit_operation'     => '<!channel> :pencil2: 一个行动被编辑了！',
     'notification_cancel_operation'   => '<!channel> :no_entry_sign: 一个行动被取消！',
     'notification_activate_operation' => '<!channel> :white_check_mark: 一个已取消的行动被重新激活了！',
+    'notification_end_operation'      => '<!here> :no_entry_sign: 此操作已结束！',
     'notification_ping_operation'     => '<!channel> :bell: ',
     'notification_enable'             => '通知到 Slack',
     'integration_channel'             => '集成频道',


### PR DESCRIPTION
Separate edited and closed operation notifications to their own. Operation will do (at)here instead of (at)everyone.