### PR TITLE
Create setting to remember default notification channel

### DIFF
--- a/src/Http/Controllers/SettingController.php
+++ b/src/Http/Controllers/SettingController.php
@@ -5,6 +5,7 @@ namespace Seat\Kassie\Calendar\Http\Controllers;
 use Illuminate\Http\Request;
 use Seat\Web\Http\Controllers\Controller;
 use Seat\Kassie\Calendar\Models\Tag;
+use Seat\Notifications\Models\Integration;
 
 /**
  * Class SettingController.
@@ -18,9 +19,11 @@ class SettingController extends Controller
      */
     public function index() {
         $tags = Tag::all();
+        $notification_channels = Integration::where('type', 'slack')->get();
 
         return view('calendar::setting.index', [
-            'tags' => $tags
+            'tags' => $tags,
+            'slackIntegrations' => $notification_channels,
         ]);
     }
 
@@ -28,8 +31,12 @@ class SettingController extends Controller
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function updateSlack(Request $request) 
+    public function updateSlack(Request $request)
     {
+        setting([
+            'kassie.calendar.slack_integration_default_channel',
+            $request->slack_integration_default_channel,
+        ], true);
         setting([
             'kassie.calendar.slack_integration',
             $request->slack_integration == 1 ? 1 : 0,

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -108,6 +108,7 @@ return [
 
     'slack_integration' => 'Slack Integration',
     'enabled'           => 'Enabled',
+    'default_channel'   => 'Default Channel',
     'webhook'           => 'Webhook',
     'emoji_full'        => 'Full Emoji',
     'emoji_half'        => 'Half Emoji',

--- a/src/resources/views/operation/modals/create_operation.blade.php
+++ b/src/resources/views/operation/modals/create_operation.blade.php
@@ -139,7 +139,14 @@
                             <select name="integration_id" id="create-operation-channel" style="width: 100%;">
                                 <option value=""></option>
                                 @foreach($notification_channels as $channel)
-                                <option value="{{ $channel->id }}">{{ $channel->name }}</option>
+                                @php
+                                    if ($channel->id == setting('kassie.calendar.slack_integration_default_channel', true)) {
+                                        $selected = "selected";
+                                    } else {
+                                        $selected = "";
+                                    }
+                                @endphp
+                                <option value="{{ $channel->id }}" {{ $selected }}>{{ $channel->name }}</option>
                                 @endforeach
                             </select>
                         </div>

--- a/src/resources/views/setting/includes/slack.blade.php
+++ b/src/resources/views/setting/includes/slack.blade.php
@@ -18,6 +18,23 @@
                         @endif
                     </div>
                 </div>
+                <label for="slack_integration_default_channel" class="col-sm-3 col-form-label">{{ trans('calendar::seat.default_channel') }}</label>
+                <div class="col-sm-9">
+                    <select name="slack_integration_default_channel" class="form-control">
+                        <option>None</option>
+
+                        @foreach ($slackIntegrations as $slackIntegration)
+                            @php
+                                if ($slackIntegration->id == setting('kassie.calendar.slack_integration_default_channel', true)) {
+                                    $selected = "selected";
+                                } else {
+                                    $selected = "";
+                                }
+                            @endphp
+                            <option value="{{ $slackIntegration->id }}" {{ $selected }}>{{ $slackIntegration->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
             </div>
 
             <p class="callout callout-info text-justify">


### PR DESCRIPTION
This adds a drop-down to the Slack settings in the calendar allowing an administrator to choose a default notification channel. If saved, this channel will be pre-selected when creating a new Operation.

<img width="390" alt="Screen Shot 2021-12-26 at 4 27 18 PM" src="https://user-images.githubusercontent.com/70491080/147420461-1ebda0ac-c55d-4d0c-a637-20d65793097c.png">
<img width="808" alt="Screen Shot 2021-12-26 at 4 26 37 PM" src="https://user-images.githubusercontent.com/70491080/147420469-30a7187f-21f9-4f7a-addd-e802a60ef252.png">

