### PR TITLE
Improve formatting of relative times

### DIFF
--- a/src/Http/Controllers/AjaxController.php
+++ b/src/Http/Controllers/AjaxController.php
@@ -114,8 +114,12 @@ class AjaxController
                     $row->start_at, human_diff($row->start_at));
             })
             ->editColumn('end_at', function ($row) {
-                return sprintf('<span data-toggle="tooltip" title="%s">%s</span>',
-                    $row->end_at, human_diff($row->end_at));
+                if ($row->end_at) {
+                    return sprintf('<span data-toggle="tooltip" title="%s">%s</span>',
+                        $row->end_at, human_diff($row->end_at));
+                } else {
+                    return '<span data-toggle="tooltip" title="no end set"></span>';
+                }
             })
             ->editColumn('fleet_commander', function ($row) {
                 return view('calendar::operation.partials.fleet_commander', ['op' => $row]);

--- a/src/Models/Operation.php
+++ b/src/Models/Operation.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use s9e\TextFormatter\Bundles\Forum as TextFormatter;
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use \DateTime;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
@@ -139,7 +140,12 @@ class Operation extends Model
      */
     public function getDurationAttribute() {
         if ($this->end_at)
-            return $this->diffToHumanFormat($this->start_at, $this->end_at);
+            return $this->start_at->diffForHumans($this->end_at,
+                [
+                    'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
+                    'options' => Carbon::ROUND,
+                ]
+            );
 
         return null;
     }
@@ -164,21 +170,36 @@ class Operation extends Model
      * @return string
      */
     public function getStartsInAttribute() {
-        return $this->diffToHumanFormat(Carbon::now('UTC'), $this->start_at);
+        return $this->start_at->diffForHumans(Carbon::now('UTC'),
+            [
+                'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
+                'options' => Carbon::ROUND,
+            ]
+        );
     }
 
     /**
      * @return string
      */
     public function getEndsInAttribute() {
-        return $this->diffToHumanFormat(Carbon::now('UTC'), $this->end_at);
+        return $this->end_at->longRelativeToNowDiffForHumans(Carbon::now('UTC'),
+            [
+                'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
+                'options' => Carbon::ROUND,
+            ]
+        );
     }
 
     /**
      * @return string
      */
     public function getStartedAttribute() {
-        return $this->diffToHumanFormat($this->start_at, Carbon::now('UTC'));
+        return $this->start_at->longRelativeToNowDiffForHumans(Carbon::now('UTC'),
+            [
+                'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
+                'options' => Carbon::ROUND,
+            ]
+        );
     }
 
     /**
@@ -192,36 +213,6 @@ class Operation extends Model
             return $entry->status;
 
         return null;
-    }
-
-    /**
-     * @param $_date1
-     * @param $_date2
-     * @return string
-     * @throws \Exception
-     */
-    private function diffToHumanFormat($_date1, $_date2) {
-        $diff = (new DateTime($_date1))->diff(new DateTime($_date2));
-
-        $duration = '';
-
-        if ($diff->m > 0)
-            $duration .= $diff->m . ' ' . trans_choice('calendar::seat.month', $diff->m) . ' ';
-
-        if ($diff->d > 0)
-            $duration .= $diff->d . ' ' . trans_choice('calendar::seat.day', $diff->d) . ' ';
-
-        if ($diff->h > 0)
-            $duration .= $diff->h . ' ' . trans_choice('calendar::seat.hour', $diff->h) . ' ';
-
-        if ($diff->i > 0)
-            $duration .= $diff->i . ' ' . trans_choice('calendar::seat.minute', $diff->i) . ' ';
-
-        if ($duration == '')
-            if ($diff->s > 0)
-                $duration .= $diff->s . ' ' . trans_choice('calendar::seat.second', $diff->s) . ' ';
-
-        return $duration;
     }
 
     /**


### PR DESCRIPTION
This improves the display of relative times.  With the current code, a operation that starts in 4 minutes 59 seconds from now is reported to start in "4 minutes". An operation starting in 1 day 23 hours is reported to start in "1 day". This leads to confusion about when the event actually starts.  Using Carbon's time rounding, we now display more intuitive relative distances.

Closes #49