### PR TITLE
Fix relative date string for event duration

### DIFF
--- a/src/Models/Operation.php
+++ b/src/Models/Operation.php
@@ -140,9 +140,9 @@ class Operation extends Model
      */
     public function getDurationAttribute() {
         if ($this->end_at)
-            return $this->start_at->diffForHumans($this->end_at,
+            return $this->end_at->diffForHumans($this->start_at,
                 [
-                    'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
+                    'syntax' => CarbonInterface::DIFF_ABSOLUTE,
                     'options' => Carbon::ROUND,
                 ]
             );


### PR DESCRIPTION
Correctly format a duration - don't refer to the duration as being in the past
<img width="556" alt="Screen Shot 2022-01-11 at 12 11 20 PM" src="https://user-images.githubusercontent.com/70491080/148989779-726766c6-81b7-477f-8b32-4605e1492e8f.png">
