### PR TITLE
Fix to correctly notify only when events actually end

### DIFF
--- a/src/Observers/OperationObserver.php
+++ b/src/Observers/OperationObserver.php
@@ -9,6 +9,7 @@ use Seat\Kassie\Calendar\Notifications\OperationUpdated;
 use Seat\Kassie\Calendar\Notifications\OperationCancelled;
 use Seat\Kassie\Calendar\Notifications\OperationActivated;
 use Seat\Kassie\Calendar\Notifications\OperationEnded;
+use Carbon\Carbon;
 
 /**
  * Class OperationObserver.
@@ -41,7 +42,8 @@ class OperationObserver
                 elseif (setting('kassie.calendar.notify_activate_operation', true))
                     Notification::send($new_operation, new OperationActivated());
             }
-            elseif ($old_operation->end_at != $new_operation->end_at &&
+            elseif ($new_operation->end_at &&
+                    $new_operation->end_at->lessThan(Carbon::now('UTC')) &&
                     $new_operation->is_cancelled == false &&
                     setting('kassie.calendar.notify_end_operation', true)) {
                 Notification::send($new_operation, new OperationEnded());


### PR DESCRIPTION
Before this change, an "event ended" notification is sent any time the event end time is changed, even if that time is in the future:
<img width="482" alt="Screen Shot 2022-01-11 at 12 33 32 PM" src="https://user-images.githubusercontent.com/70491080/148993203-fe09b04f-7a92-4482-a9a6-d6c5a3531096.png">

This fixes the logic to only show that the event was edited:

<img width="535" alt="Screen Shot 2022-01-11 at 12 33 55 PM" src="https://user-images.githubusercontent.com/70491080/148993310-30237233-3de8-4176-8169-3c01530a90c1.png">

