### PR TITLE
Notification content enhancements

### DIFF
--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -62,6 +62,7 @@ class Helper
                 setting('kassie.calendar.slack_emoji_importance_empty', true));
 
         $fields[trans('calendar::seat.fleet_commander')] = $op->fc ? $op->fc : trans('calendar::seat.unknown');
+        $fields[trans('calendar::seat.staging_system')] = $op->staging_sys ? $op->staging_sys : trans('calendar::seat.unknown');
 
         return function ($attachment) use ($op, $url, $fields) {
             $attachment->title($op->title, $url)

--- a/src/Notifications/OperationPinged.php
+++ b/src/Notifications/OperationPinged.php
@@ -5,6 +5,7 @@ namespace Seat\Kassie\Calendar\Notifications;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Kassie\Calendar\Helpers\Helper;
 
 /**
  * Class OperationPinged.
@@ -30,11 +31,12 @@ class OperationPinged extends Notification
      */
     public function toSlack($notifiable)
     {
-        $content = trans('calendar::seat.notification_ping_operation') . '*' . trans('calendar::seat.starts_in') . ' ' . $notifiable->starts_in . '* : <' . url('/calendar/operation') . '|' . $notifiable->title . '>';
+        $attachment = Helper::BuildSlackNotificationAttachment($notifiable);
 
         return (new SlackMessage)
             ->success()
             ->from('SeAT Calendar', ':calendar:')
-            ->content($content);
+            ->content(trans('calendar::seat.notification_ping_operation') . '*' . trans('calendar::seat.starts_in') . ' ' . $notifiable->starts_in . '*')
+            ->attachment($attachment);
     }
 }

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -96,6 +96,7 @@ return [
     'staging_sys'     => 'Staging system',
     'staging_info'    => 'Staging info',
     'fleet_commander' => 'Fleet Commander',
+    'staging_system'  => 'Staging System',
     'character'       => 'Character',
 
     'notification_new_operation'      => '<!channel> :rocket: A new operation has been posted !',


### PR DESCRIPTION
This PR improves notifications in two ways:

1. Shows the staging system
2. Show the full details each time the operation is pinged

The previous operation ping content did not correctly link to an event, so there was no way to get more detail. It also required the user to click, rather than see the snapshot of what is about to go down.

Screenshot:
<img width="492" alt="Screen Shot 2022-01-11 at 12 42 45 PM" src="https://user-images.githubusercontent.com/70491080/148994143-143162ea-e546-4ddc-9f73-9ab52a3222fa.png">

