### PR TITLE
Default new events to have an end time

### DIFF
--- a/src/resources/assets/js/calendar.js
+++ b/src/resources/assets/js/calendar.js
@@ -24,7 +24,7 @@ op_modals.create.on('show.bs.modal', function (e) {
     options.singleDatePicker = true;
     op_modals.create.find('input[name="time_start"]').daterangepicker(options);
     options.singleDatePicker = false;
-    options.endDate = nowRounded.clone().add('2', 'h');
+    options.endDate = nowRounded.clone().add('3', 'h');
     op_modals.create.find('input[name="time_start_end"]').daterangepicker(options);
 
     if ($('#sliderImportance').length <= 0)
@@ -100,8 +100,8 @@ op_modals.update.on('show.bs.modal', function (e) {
     nowRounded = moment.utc();
     nowRounded = moment.utc(Math.ceil((+nowRounded) / ROUNDING) * ROUNDING);
 
-    op_modals.update.find('input[name="known_duration"][value="yes"]').prop('checked', false);
-    op_modals.update.find('input[name="known_duration"][value="no"]').prop('checked', true);
+    op_modals.update.find('input[name="known_duration"][value="yes"]').prop('checked', true);
+    op_modals.update.find('input[name="known_duration"][value="no"]').prop('checked', false);
     op_modals.update.find('input[name="time_start"]').closest('div.form-group').removeClass('d-none');
     op_modals.update.find('input[name="time_start_end"]').closest('div.form-group').addClass('d-none');
 
@@ -152,7 +152,7 @@ op_modals.update.on('show.bs.modal', function (e) {
             op_modals.update.find('input[name="time_start"]').closest('div.form-group').addClass('hidden');
             op_modals.update.find('input[name="time_start_end"]').closest('div.form-group').removeClass('hidden');
         } else {
-            options.endDate = moment.utc(op.start_at).clone().add('2', 'h');
+            options.endDate = moment.utc(op.start_at).clone().add('3', 'h');
             op_modals.update.find('input[name="time_start"]').closest('div.form-group').removeClass('hidden');
             op_modals.update.find('input[name="time_start_end"]').closest('div.form-group').addClass('hidden');
         }

--- a/src/resources/views/operation/modals/create_operation.blade.php
+++ b/src/resources/views/operation/modals/create_operation.blade.php
@@ -69,15 +69,15 @@
                         <label for="known_duration" class="col-sm-3 col-form-label">{{ trans('calendar::seat.known_duration') }}</label>
                         <div class="col-sm-9">
                             <label class="radio-inline">
-                                <input type="radio" name="known_duration" value="yes"> {{ trans('calendar::seat.yes') }}
+                                <input type="radio" name="known_duration" value="yes" checked> {{ trans('calendar::seat.yes') }}
                             </label>
                             <label class="radio-inline">
-                                <input type="radio" name="known_duration" value="no" checked> {{ trans('calendar::seat.no') }}
+                                <input type="radio" name="known_duration" value="no"> {{ trans('calendar::seat.no') }}
                             </label>
                         </div>
                     </div>
                     {{-- Operation starts --}}
-                    <div class="form-group row datepicker">
+                    <div class="form-group row datepicker d-none">
                         <label for="time_start" class="col-sm-3 col-form-label">{{ trans('calendar::seat.starts_at') }}
                             <span class="text-danger">*</span>
                         </label>
@@ -86,7 +86,7 @@
                         </div>
                     </div>
                     {{-- Operation duration --}}
-                    <div class="form-group row datepicker d-none">
+                    <div class="form-group row datepicker">
                         <label for="time_start_end" class="col-sm-3 col-form-label">{{ trans('calendar::seat.duration') }}
                             <span class="text-danger">*</span>
                         </label>

--- a/src/resources/views/operation/modals/update_operation.blade.php
+++ b/src/resources/views/operation/modals/update_operation.blade.php
@@ -75,15 +75,15 @@
                         <label for="known_duration" class="col-sm-3 col-form-label">{{ trans('calendar::seat.known_duration') }}</label>
                         <div class="col-sm-9">
                             <label class="radio-inline">
-                                <input type="radio" name="known_duration" value="yes"> {{ trans('calendar::seat.yes') }}
+                                <input type="radio" name="known_duration" value="yes" checked> {{ trans('calendar::seat.yes') }}
                             </label>
                             <label class="radio-inline">
-                                <input type="radio" name="known_duration" value="no" checked> {{ trans('calendar::seat.no') }}
+                                <input type="radio" name="known_duration" value="no"> {{ trans('calendar::seat.no') }}
                             </label>
                         </div>
                     </div>
                     {{-- Operation starts --}}
-                    <div class="form-group row datepicker">
+                    <div class="form-group row datepicker d-none">
                         <label for="time_start" class="col-sm-3 col-form-label">{{ trans('calendar::seat.starts_at') }}
                             <span class="text-danger">*</span>
                         </label>
@@ -92,7 +92,7 @@
                         </div>
                     </div>
                     {{-- Operation duration --}}
-                    <div class="form-group row datepicker d-none">
+                    <div class="form-group row datepicker">
                         <label for="time_start_end" class="col-sm-3 col-form-label">{{ trans('calendar::seat.duration') }}
                             <span class="text-danger">*</span>
                         </label>


### PR DESCRIPTION
By default, events have no end. This often leads to events being created that never end, cluttering up the UI with stale data. Make them end by default, and still allow people to opt into events that have no end.